### PR TITLE
Rename organization to `nmi-agro`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,11 +22,11 @@ Imports:
     parallelly,
     ggplot2,
     deSolve
-Remotes: AgroCares/rotsee
+Remotes: nmi-agro/rotsee
 License: 
     GPL-3
-URL: https://github.com/AgroCares/rotsee
-BugReports: https://github.com/AgroCares/rotsee/issues
+URL: https://github.com/nmi-agro/rotsee
+BugReports: https://github.com/nmi-agro/rotsee/issues
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.3.3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rotsee
 Type: Package
 Title: Calculator for simulation Soil Organic Carbon stocks in agricultural soil
-Version: 0.0.1.9000
+Version: 0.2.3
 Authors@R: c(
     person("Gerard", "Ros", email = "gerard.ros@nmi-agro.nl", role = c("aut","cre")),
     person("Sven", "Verweij", email = "sven.verweij@nmi-agro.nl", role = c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# rotsee v0.2.3 2026-02-11
+## changed
+* Rename organization to `nmi-agro`
+
 # rotsee v0.2.2 2026-01-09
 ## added
 * test helper factories to aid with unit test creation

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <!-- badges: start -->
 [![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html)
-[![R-CMD-check](https://github.com/AgroCares/rotsee/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/AgroCares/rotsee/actions/workflows/R-CMD-check.yaml)
+[![R-CMD-check](https://github.com/nmi-agro/rotsee/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/nmi-agro/rotsee/actions/workflows/R-CMD-check.yaml)
 <!-- badges: end -->
 
 > [!NOTE]
@@ -20,7 +20,7 @@ You can install the development version of rotsee from [GitHub](https://github.c
 
 ``` r
 # install.packages("devtools")
-devtools::install_github("AgroCares/rotsee")
+devtools::install_github("nmi-agro/rotsee")
 ```
 
 ## Usage
@@ -45,4 +45,4 @@ The `rotsee` package is developed and maintained by the [Nutrienten Management I
 
 ## Contact
 
-For questions, bug reports, and suggestions, please use the [issue tracker](https://github.com/AgroCares/rotsee/issues).
+For questions, bug reports, and suggestions, please use the [issue tracker](https://github.com/nmi-agro/rotsee/issues).


### PR DESCRIPTION
# rotsee v0.2.3 2026-02-11
## changed
* Rename organization to `nmi-agro`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped version to 0.2.3.
  * Updated package metadata including author information, description, and remote references.

* **Documentation**
  * Updated repository references and badges throughout documentation.
  * Refreshed installation instructions with updated repository URLs.
  * Updated issue tracker and bug report links to reflect organizational transition.
  * Added changelog entry documenting the version release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->